### PR TITLE
implement delay status

### DIFF
--- a/services/backend/core/export_shipment.py
+++ b/services/backend/core/export_shipment.py
@@ -24,6 +24,7 @@ class ExportShipment(db.Model):
     ocean_bl = db.Column(db.String, nullable=False)
     port_disc_id = db.Column(db.String, nullable=False)
     cr_agent_id = db.Column(db.String, nullable=False)
+    og_eta = db.Column(db.Date, nullable=False)
 
     def __init__(self, export_ref_n, eta, ocean_bl, port_disc_id, cr_agent_id):
         self.export_ref_n = export_ref_n
@@ -184,6 +185,52 @@ def get_agent_id():
             {
                 "code": 500,
                 "message": "Failed to retrieve CR_AGENT_ID"
+            }
+        ), 500
+
+# Retrieve delay status by export_ref_n
+@app.route("/export_shipment/delay", methods=['POST'])
+def get_delay_status():
+    data = request.get_json()
+    export_ref_n = data["export_ref_n"]
+    
+    try:
+        eta = ExportShipment.query.filter_by(export_ref_n=export_ref_n).first().eta
+        og_eta = ExportShipment.query.filter_by(export_ref_n=export_ref_n).first().og_eta
+
+        if eta > og_eta:
+            return jsonify(
+                {
+                    "code": 200,
+                    "data": {
+                        "status": "delayed"
+                        }
+                }
+            ), 200
+        elif eta == og_eta:
+            return jsonify(
+                {
+                    "code": 200,
+                    "data": {
+                        "status": "on time"
+                        }
+                }
+            ), 200
+        else:
+            return jsonify(
+                {
+                    "code": 200,
+                    "data": {
+                        "status": "early"
+                        }
+                }
+            ), 200
+    
+    except:
+        return jsonify(
+            {
+                "code": 500,
+                "message": "Failed to retrieve delay status"
             }
         ), 500
 

--- a/services/backend/core/import_shipment.py
+++ b/services/backend/core/import_shipment.py
@@ -24,6 +24,7 @@ class ImportShipment(db.Model):
     ocean_bl = db.Column(db.String, nullable=False)
     cr_agent_id = db.Column(db.String, nullable=False)
     port_load_id = db.Column(db.String, nullable=False)
+    og_eta = db.Column(db.Date, nullable=False)
 
     def __init__(self, import_ref_n, eta, ocean_bl, cr_agent_id, port_load_id):
         self.import_ref_n = import_ref_n
@@ -182,6 +183,53 @@ def get_agent_id():
             {
                 "code": 500,
                 "message": "Failed to retrieve CR_AGENT_ID"
+            }
+        ), 500
+
+
+# Retrieve delay status by import_ref_n
+@app.route("/import_shipment/delay", methods=['POST'])
+def get_delay_status():
+    data = request.get_json()
+    import_ref_n = data["import_ref_n"]
+    
+    try:
+        eta = ImportShipment.query.filter_by(import_ref_n=import_ref_n).first().eta
+        og_eta = ImportShipment.query.filter_by(import_ref_n=import_ref_n).first().og_eta
+
+        if eta > og_eta:
+            return jsonify(
+                {
+                    "code": 200,
+                    "data": {
+                        "status": "delayed"
+                        }
+                }
+            ), 200
+        elif eta == og_eta:
+            return jsonify(
+                {
+                    "code": 200,
+                    "data": {
+                        "status": "on time"
+                        }
+                }
+            ), 200
+        else:
+            return jsonify(
+                {
+                    "code": 200,
+                    "data": {
+                        "status": "early"
+                        }
+                }
+            ), 200
+    
+    except:
+        return jsonify(
+            {
+                "code": 500,
+                "message": "Failed to retrieve delay status"
             }
         ), 500
 


### PR DESCRIPTION
# Description
Added the retrieval of a "delay status" from the BE so that FE can display to users whether a shipment is "early", "on time" or "delayed".

This value is passed in the `delay_status` parameter of the JSON response.

Tested and works with YMLU scraper for import/cont, import/bl, export/cont & export/bl.

<img width="424" alt="image" src="https://user-images.githubusercontent.com/70679812/223180860-a9117518-4f37-4fe2-8b3d-8c143dea75fa.png">

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactor
- [ ] Migration

# Checklist:

- [x] I have added the appropriate labels to my PR
- [ ] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes